### PR TITLE
Fix chroot_dir, give precedent to user setting

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -34,7 +34,7 @@ then
 fi
 
 ARCH=amd64
-CHROOT_DIR=/srv/chroot
+CHROOT_DIR=
 CHROOT_GROUP=
 CHROOT_NAME=
 CHROOT_USER=
@@ -100,10 +100,16 @@ then
     exit 1
 fi
 
+if [ -z "$CHROOT_DIR" ]
+then
+    CHROOT_DIR="$(pwd)/$CHROOT_NAME"
+    echo "$INFO \`--dir\` not set, defaulting to $CHROOT_DIR (the current working directory + the chroot name)."
+fi
+
 CONFIG="[$CHROOT_NAME]\
 \ndescription=Debian ($DEBIAN_RELEASE)\
 \ntype=$TYPE\
-\ndirectory=$(pwd)/$CHROOT_DIR/$CHROOT_NAME\
+\ndirectory=$CHROOT_DIR\
 \npersonality=$PERSONALITY\
 \nprofile=$PROFILE\
 \nusers=$CHROOT_USER\


### PR DESCRIPTION
The shell script was not honoring the `--dir` command-line option.

If the option is set, it will use it expliclty:
```
$ sudo ./install.sh --chroot onion --group sudo --release bullseye --type directory --profile minimal --dir /foo --dry-run
[./install.sh][INFO] Installing debootstrap and schroot, if missing.
[onion]
description=Debian (bullseye)
type=directory
directory=/foo
personality=linux
profile=minimal
users=
root-users=
groups=sudo
root-groups=sudo
```

Else, it will default to concatenating the current working directory and the `chroot` name and add a log to `stdout`:
```
$ sudo ./install.sh --chroot onion --group sudo --release bullseye --type directory --profile minimal --dry-run
[./install.sh][INFO] Installing debootstrap and schroot, if missing.
[./install.sh][INFO] `--dir` not set, defaulting to /home/btoll/projects/chroot/onion (the current working directory + the chroot name).
[onion]
description=Debian (bullseye)
type=directory
directory=/home/btoll/projects/chroot/onion
personality=linux
profile=minimal
users=
root-users=
groups=sudo
root-groups=sudo
```